### PR TITLE
[feat] 9주차 API & Paging

### DIFF
--- a/src/main/generated/org/example/umcmission/domain/mapping/QMemberMission.java
+++ b/src/main/generated/org/example/umcmission/domain/mapping/QMemberMission.java
@@ -24,6 +24,8 @@ public class QMemberMission extends EntityPathBase<MemberMission> {
 
     public final org.example.umcmission.domain.base.QBaseEntity _super = new org.example.umcmission.domain.base.QBaseEntity(this);
 
+    public final DateTimePath<java.time.LocalDateTime> completedAt = createDateTime("completedAt", java.time.LocalDateTime.class);
+
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
 

--- a/src/main/java/org/example/umcmission/controller/MissionController.java
+++ b/src/main/java/org/example/umcmission/controller/MissionController.java
@@ -12,7 +12,6 @@ import org.example.umcmission.service.MissionService.MemberMissionCommandService
 import org.example.umcmission.service.MissionService.MemberMissionQueryService;
 import org.example.umcmission.service.MissionService.MissionCommandService;
 import org.example.umcmission.service.MissionService.MissionQueryService;
-import org.example.umcmission.validation.annotaion.AlreadyChallenging;
 import org.example.umcmission.validation.annotaion.CheckPage;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -21,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/missions")
 @Tag(name = "미션 관련 API")
+@Validated
 public class MissionController {
     private final MissionCommandService missionCommandService;
     private final MissionQueryService missionQueryService;
@@ -45,7 +45,7 @@ public class MissionController {
     @Operation(method = "GET", summary = "특정 가게 미션 조회 API", description = "특정 가게의 미션을 조회하는 API입니다.")
     public ApiResponse<MissionResDTO.MissionPreViewListDTO> getMissions(
             @PathVariable Long storeId,
-            @CheckPage @RequestParam int page,
+            @CheckPage@RequestParam int page,
             @CheckPage@RequestParam int size
     ){
         MissionResDTO.MissionPreViewListDTO missionPreViewListDTO = missionQueryService.getMissions(storeId,page,size);

--- a/src/main/java/org/example/umcmission/controller/MissionController.java
+++ b/src/main/java/org/example/umcmission/controller/MissionController.java
@@ -6,9 +6,14 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.umcmission.apiPayload.ApiResponse;
 import org.example.umcmission.dto.requestDTO.MissionReqDTO;
+import org.example.umcmission.dto.responseDTO.MemberMissionResDTO;
 import org.example.umcmission.dto.responseDTO.MissionResDTO;
+import org.example.umcmission.service.MissionService.MemberMissionCommandService;
+import org.example.umcmission.service.MissionService.MemberMissionQueryService;
 import org.example.umcmission.service.MissionService.MissionCommandService;
+import org.example.umcmission.service.MissionService.MissionQueryService;
 import org.example.umcmission.validation.annotaion.AlreadyChallenging;
+import org.example.umcmission.validation.annotaion.CheckPage;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,8 +23,10 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "미션 관련 API")
 public class MissionController {
     private final MissionCommandService missionCommandService;
+    private final MissionQueryService missionQueryService;
+    private final MemberMissionQueryService memberMissionQueryService;
+    private final MemberMissionCommandService memberMissionCommandService;
 
-    //3. 가게에 미션 추가하기 API
     @PostMapping("")
     @Operation(method = "POST", summary = "미션 추가 API", description = "해당 가게에 미션을 추가하는 API입니다.")
     public ApiResponse<MissionResDTO.MissionPreviewDTO> createMission(@Valid@RequestBody MissionReqDTO.CreateMissionDTO dto){
@@ -27,11 +34,39 @@ public class MissionController {
 
         return ApiResponse.onSuccess(missionPreviewDTO);
     }
-    //4. 가게의 미션을 도전 중인 미션에 추가(미션 도전하기) API
     @PostMapping("/challenging")
     @Operation(method = "POST", summary = "도전 중인 미션 추가 API", description = "미션의 상태를 도전 중으로 수정하는 API입니다.")
-    private ApiResponse<MissionResDTO.MissionPreviewDTO> updateMissionStatus(@Valid@RequestBody MissionReqDTO.ChallengingMissionDTO dto){
+    public ApiResponse<MissionResDTO.MissionPreviewDTO> updateMissionStatus(@Valid@RequestBody MissionReqDTO.ChallengingMissionDTO dto){
         MissionResDTO.MissionPreviewDTO missionPreviewDTO = missionCommandService.createChallengingMission(dto);
         return ApiResponse.onSuccess(missionPreviewDTO);
+    }
+
+    @GetMapping("/{storeId}")
+    @Operation(method = "GET", summary = "특정 가게 미션 조회 API", description = "특정 가게의 미션을 조회하는 API입니다.")
+    public ApiResponse<MissionResDTO.MissionPreViewListDTO> getMissions(
+            @PathVariable Long storeId,
+            @CheckPage @RequestParam int page,
+            @CheckPage@RequestParam int size
+    ){
+        MissionResDTO.MissionPreViewListDTO missionPreViewListDTO = missionQueryService.getMissions(storeId,page,size);
+        return ApiResponse.onSuccess(missionPreViewListDTO);
+    }
+
+    @GetMapping("/members/{memberId}")
+    @Operation(method = "GET", summary = "내가 진행 중인 미션 조회 API", description = "특정 유저가 진행 중인 미션을 조회하는 API입니다.")
+    public ApiResponse<MemberMissionResDTO.MemberMissionListDTO> getChallengingMissions(
+            @PathVariable Long memberId,
+            @CheckPage@RequestParam int page,
+            @CheckPage@RequestParam int size
+    ){
+        MemberMissionResDTO.MemberMissionListDTO memberMissionListDTO = memberMissionQueryService.getChallengingMissions(memberId, page-1,size);
+        return ApiResponse.onSuccess(memberMissionListDTO);
+    }
+
+    @PatchMapping("/members/{memberMissionId}/complete")
+    @Operation(method = "PATCH", summary = "진행 중인 미션 완료 처리 API", description = "특정 유저가 진행 중인 미션을 완료로 수정하는 API입니다.")
+    public ApiResponse<String> completeMission(@PathVariable Long memberMissionId){
+        memberMissionCommandService.completeMission(memberMissionId);
+        return ApiResponse.onSuccess("성공적으로 변경되었습니다.");
     }
 }

--- a/src/main/java/org/example/umcmission/controller/ReviewController.java
+++ b/src/main/java/org/example/umcmission/controller/ReviewController.java
@@ -8,28 +8,33 @@ import org.example.umcmission.apiPayload.ApiResponse;
 import org.example.umcmission.dto.requestDTO.ReviewReqDTO;
 import org.example.umcmission.dto.responseDTO.ReviewResDTO;
 import org.example.umcmission.service.ReviewService.ReviewCommandService;
+import org.example.umcmission.service.ReviewService.ReviewQueryService;
+import org.example.umcmission.validation.annotaion.CheckPage;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/reviews")
 @Tag(name = "리뷰 관련 API")
-@Validated
 public class ReviewController {
     private final ReviewCommandService reviewCommandService;
+    private final ReviewQueryService reviewQueryService;
 
-    //2. 가게에 리뷰 추가하기 API
     @PostMapping("")
     @Operation(method = "POST", summary = "리뷰 추가 API", description = "가게에 리뷰를 추가하는 API입니다.")
     public ApiResponse<ReviewResDTO.ReviewPreviewDTO> createReview(@Valid @RequestBody ReviewReqDTO.CreateReviewReqDTO dto){
-
-
         ReviewResDTO.ReviewPreviewDTO reviewPreviewDTO = reviewCommandService.createReview(dto);
-
         return ApiResponse.onSuccess(reviewPreviewDTO);
+    }
+
+    @GetMapping("/{memberId}")
+    @Operation(method = "GET", summary = "내가 작성한 리뷰 목록 조회", description = "특정 유저가 작성한 리뷰를 조회하는 API입니다")
+    public ApiResponse<ReviewResDTO.ReviewPreViewListDTO> getReviews(
+            @PathVariable Long memberId,
+            @CheckPage@RequestParam int page,
+            @CheckPage@RequestParam int size){
+        ReviewResDTO.ReviewPreViewListDTO reviewPagePreviewDTO = reviewQueryService.getReviews(memberId, page,size);
+        return ApiResponse.onSuccess(reviewPagePreviewDTO);
     }
 }

--- a/src/main/java/org/example/umcmission/controller/StoreController.java
+++ b/src/main/java/org/example/umcmission/controller/StoreController.java
@@ -1,18 +1,25 @@
 package org.example.umcmission.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.umcmission.apiPayload.ApiResponse;
+import org.example.umcmission.converter.StoreConverter;
+import org.example.umcmission.domain.Review;
 import org.example.umcmission.dto.requestDTO.StoreReqDTO;
 import org.example.umcmission.dto.responseDTO.StoreResDTO;
 import org.example.umcmission.service.StoreService.StoreCommandService;
+import org.example.umcmission.service.StoreService.StoreQueryService;
+import org.example.umcmission.validation.annotaion.ExistStores;
+import org.springframework.data.domain.Page;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 public class StoreController {
     private final StoreCommandService storeCommandService;
+    private final StoreQueryService storeQueryService;
     //1. 특정 지역에 가게 추가하기 API
     @PostMapping("")
     @Operation(method = "POST",summary = "가게 생성 API", description = "특정 지역에 가게를 생성하는 API")
@@ -28,5 +36,21 @@ public class StoreController {
         StoreResDTO.StorePreviewDTO storePreviewDTO = storeCommandService.createStore(dto);
 
         return ApiResponse.onSuccess(storePreviewDTO);
+    }
+
+    @GetMapping("/{storeId}/reviews")
+    @Operation(summary = "특정 가게의 리뷰 목록 조회 API",description = "특정 가게의 리뷰들의 목록을 조회하는 API이며, 페이징을 포함합니다. query String 으로 page 번호를 주세요")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "acess 토큰 만료",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "acess 토큰 모양이 이상함",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "storeId", description = "가게의 아이디, path variable 입니다!")
+    })
+    public ApiResponse<StoreResDTO.ReviewPreViewListDTO> getReviewList(@ExistStores @PathVariable(name = "storeId") Long storeId, @RequestParam(name = "page") Integer page){
+        Page<Review> reviewList = storeQueryService.getReviewList(storeId,page);
+        return ApiResponse.onSuccess(StoreConverter.reviewPreViewListDTO(reviewList));
     }
 }

--- a/src/main/java/org/example/umcmission/converter/MemberMissionConverter.java
+++ b/src/main/java/org/example/umcmission/converter/MemberMissionConverter.java
@@ -5,7 +5,12 @@ import org.example.umcmission.domain.Mission;
 import org.example.umcmission.domain.enums.MissionStatus;
 import org.example.umcmission.domain.mapping.MemberMission;
 import org.example.umcmission.dto.requestDTO.MissionReqDTO;
+import org.example.umcmission.dto.responseDTO.MemberMissionResDTO;
 import org.example.umcmission.dto.responseDTO.MissionResDTO;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class MemberMissionConverter {
     public static MemberMission toMemberMission(MissionReqDTO.ChallengingMissionDTO dto, Member member, Mission mission) {
@@ -23,5 +28,27 @@ public class MemberMissionConverter {
                 .createdAt(memberMission.getCreatedAt())
                 .updatedAt(memberMission.getUpdatedAt())
                 .build();
+    }
+
+    public static MemberMissionResDTO.MemberMissionListDTO toUserMissionListDTO(Page<MemberMission> memberMissionPage) {
+        return MemberMissionResDTO.MemberMissionListDTO.builder()
+                .missionList(toUserMissionPreviewList(memberMissionPage.getContent()))
+                .listSize(memberMissionPage.getNumberOfElements())
+                .totalPage(memberMissionPage.getTotalPages())
+                .totalElements(memberMissionPage.getTotalElements())
+                .isFirst(memberMissionPage.isFirst())
+                .isLast(memberMissionPage.isLast())
+                .build();
+    }
+
+    public static List<MemberMissionResDTO.MemberMissionPreviewDTO> toUserMissionPreviewList(List<MemberMission> userMissions) {
+        return userMissions.stream()
+                .map(mission -> MemberMissionResDTO.MemberMissionPreviewDTO.builder()
+                        .missionId(mission.getMission().getId())
+                        .reward(mission.getMission().getReward())
+                        .deadline(mission.getMission().getDeadline())
+                        .status(mission.getStatus().name())
+                        .build())
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/example/umcmission/converter/MissionConverter.java
+++ b/src/main/java/org/example/umcmission/converter/MissionConverter.java
@@ -1,9 +1,15 @@
 package org.example.umcmission.converter;
 
 import org.example.umcmission.domain.Mission;
+import org.example.umcmission.domain.Review;
 import org.example.umcmission.domain.Store;
 import org.example.umcmission.dto.requestDTO.MissionReqDTO;
 import org.example.umcmission.dto.responseDTO.MissionResDTO;
+import org.example.umcmission.dto.responseDTO.ReviewResDTO;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class MissionConverter {
     public static Mission toMission(MissionReqDTO.CreateMissionDTO dto, Store store) {
@@ -25,6 +31,28 @@ public class MissionConverter {
                 .missionStatus(mission.getMissionStatus())
                 .createdAt(mission.getCreatedAt())
                 .updatedAt(mission.getUpdatedAt())
+                .build();
+    }
+
+    public static List<MissionResDTO.MissionPreviewDTO> toMissionPreviewList(List<Mission> missions) {
+        return missions.stream()
+                .map(mission -> MissionResDTO.MissionPreviewDTO.builder()
+                        .id(mission.getId())
+                        .reward(mission.getReward())
+                        .missionStatus(mission.getMissionStatus())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    // 페이지 전체를 변환
+    public static MissionResDTO.MissionPreViewListDTO toMissionPreviewListDTO(Page<Mission> missionPage) {
+        return MissionResDTO.MissionPreViewListDTO.builder()
+                .missionList(toMissionPreviewList(missionPage.getContent())) // 리뷰 리스트 변환
+                .listSize(missionPage.getContent().size()) // 현재 페이지의 리뷰 개수
+                .totalPage(missionPage.getTotalPages())    // 전체 페이지 수
+                .totalElements(missionPage.getTotalElements()) // 전체 리뷰 수
+                .isFirst(missionPage.isFirst())            // 첫 페이지 여부
+                .isLast(missionPage.isLast())              // 마지막 페이지 여부
                 .build();
     }
 }

--- a/src/main/java/org/example/umcmission/converter/ReviewConverter.java
+++ b/src/main/java/org/example/umcmission/converter/ReviewConverter.java
@@ -5,6 +5,11 @@ import org.example.umcmission.domain.Review;
 import org.example.umcmission.domain.Store;
 import org.example.umcmission.dto.requestDTO.ReviewReqDTO;
 import org.example.umcmission.dto.responseDTO.ReviewResDTO;
+import org.example.umcmission.dto.responseDTO.StoreResDTO;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class ReviewConverter {
     public static Review toReview(ReviewReqDTO.CreateReviewReqDTO dto, Store store, Member member) {
@@ -28,6 +33,29 @@ public class ReviewConverter {
                 .reviewImageList(review.getReviewImageList())
                 .createdAt(review.getCreatedAt())
                 .updatedAt(review.getUpdatedAt())
+                .build();
+    }
+
+    public static List<ReviewResDTO.ReviewPreviewDTO> toReviewPreviewList(List<Review> reviews) {
+        return reviews.stream()
+                .map(review -> ReviewResDTO.ReviewPreviewDTO.builder()
+                        .id(review.getId())
+                        .title(review.getTitle())
+                        .score(review.getScore())
+                        .body(review.getBody()) // 본문 프리뷰
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    // 페이지 전체를 변환
+    public static ReviewResDTO.ReviewPreViewListDTO toReviewPreviewListDTO(Page<Review> reviewPage) {
+        return ReviewResDTO.ReviewPreViewListDTO.builder()
+                .reviewList(toReviewPreviewList(reviewPage.getContent())) // 리뷰 리스트 변환
+                .listSize(reviewPage.getContent().size()) // 현재 페이지의 리뷰 개수
+                .totalPage(reviewPage.getTotalPages())    // 전체 페이지 수
+                .totalElements(reviewPage.getTotalElements()) // 전체 리뷰 수
+                .isFirst(reviewPage.isFirst())            // 첫 페이지 여부
+                .isLast(reviewPage.isLast())              // 마지막 페이지 여부
                 .build();
     }
 }

--- a/src/main/java/org/example/umcmission/converter/StoreConverter.java
+++ b/src/main/java/org/example/umcmission/converter/StoreConverter.java
@@ -1,9 +1,14 @@
 package org.example.umcmission.converter;
 
 import org.example.umcmission.domain.Region;
+import org.example.umcmission.domain.Review;
 import org.example.umcmission.domain.Store;
 import org.example.umcmission.dto.requestDTO.StoreReqDTO;
 import org.example.umcmission.dto.responseDTO.StoreResDTO;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class StoreConverter {
     public static Store toStore(StoreReqDTO.CreatStoreReqDTO dto, Region region) {
@@ -26,6 +31,29 @@ public class StoreConverter {
                 .reviewList(store.getReviewList())
                 .createdAt(store.getCreatedAt())
                 .updatedAt(store.getUpdatedAt())
+                .build();
+    }
+
+    public static StoreResDTO.ReviewPreViewDTO reviewPreViewDTO(Review review){
+        return StoreResDTO.ReviewPreViewDTO.builder()
+                .ownerNickname(review.getMember().getName())
+                .score(review.getScore())
+                .createdAt(review.getCreatedAt().toLocalDate())
+                .body(review.getBody())
+                .build();
+    }
+    public static StoreResDTO.ReviewPreViewListDTO reviewPreViewListDTO(Page<Review> reviewList){
+
+        List<StoreResDTO.ReviewPreViewDTO> reviewPreViewDTOList = reviewList.stream()
+                .map(StoreConverter::reviewPreViewDTO).collect(Collectors.toList());
+
+        return StoreResDTO.ReviewPreViewListDTO.builder()
+                .isLast(reviewList.isLast())
+                .isFirst(reviewList.isFirst())
+                .totalPage(reviewList.getTotalPages())
+                .totalElements(reviewList.getTotalElements())
+                .listSize(reviewPreViewDTOList.size())
+                .reviewList(reviewPreViewDTOList)
                 .build();
     }
 }

--- a/src/main/java/org/example/umcmission/domain/mapping/MemberMission.java
+++ b/src/main/java/org/example/umcmission/domain/mapping/MemberMission.java
@@ -6,6 +6,8 @@ import org.example.umcmission.domain.Mission;
 import org.example.umcmission.domain.base.BaseEntity;
 import org.example.umcmission.domain.enums.MissionStatus;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Builder
@@ -17,6 +19,9 @@ public class MemberMission extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
     @Enumerated(EnumType.STRING)
     private MissionStatus status;
 
@@ -27,4 +32,12 @@ public class MemberMission extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "mission_id")
     private Mission mission;
+
+    public void setStatus(MissionStatus status) {
+        this.status = status;
+    }
+
+    public void setCompletedAt(LocalDateTime completedAt) {
+        this.completedAt = completedAt;
+    }
 }

--- a/src/main/java/org/example/umcmission/dto/responseDTO/MemberMissionResDTO.java
+++ b/src/main/java/org/example/umcmission/dto/responseDTO/MemberMissionResDTO.java
@@ -1,0 +1,29 @@
+package org.example.umcmission.dto.responseDTO;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class MemberMissionResDTO {
+    @Builder
+    @Getter
+    public static class MemberMissionListDTO {
+        private List<MemberMissionPreviewDTO> missionList;
+        private Integer listSize;
+        private Integer totalPage;
+        private Long totalElements;
+        private Boolean isFirst;
+        private Boolean isLast;
+    }
+
+    @Builder
+    @Getter
+    public static class MemberMissionPreviewDTO {
+        private Long missionId;
+        private Integer reward;
+        private LocalDate deadline;
+        private String status;
+    }
+}

--- a/src/main/java/org/example/umcmission/dto/responseDTO/MissionResDTO.java
+++ b/src/main/java/org/example/umcmission/dto/responseDTO/MissionResDTO.java
@@ -24,4 +24,17 @@ public class MissionResDTO {
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MissionPreViewListDTO {
+        private List<MissionResDTO.MissionPreviewDTO> missionList; // 리뷰 목록
+        private Integer listSize;                  // 현재 페이지의 리뷰 수
+        private Integer totalPage;                 // 전체 페이지 수
+        private Long totalElements;                // 전체 리뷰 수
+        private Boolean isFirst;                   // 첫 페이지 여부
+        private Boolean isLast;                    // 마지막 페이지 여부
+    }
 }

--- a/src/main/java/org/example/umcmission/dto/responseDTO/ReviewResDTO.java
+++ b/src/main/java/org/example/umcmission/dto/responseDTO/ReviewResDTO.java
@@ -22,4 +22,17 @@ public class ReviewResDTO {
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReviewPreViewListDTO {
+        private List<ReviewPreviewDTO> reviewList; // 리뷰 목록
+        private Integer listSize;                  // 현재 페이지의 리뷰 수
+        private Integer totalPage;                 // 전체 페이지 수
+        private Long totalElements;                // 전체 리뷰 수
+        private Boolean isFirst;                   // 첫 페이지 여부
+        private Boolean isLast;                    // 마지막 페이지 여부
+    }
 }

--- a/src/main/java/org/example/umcmission/dto/responseDTO/StoreResDTO.java
+++ b/src/main/java/org/example/umcmission/dto/responseDTO/StoreResDTO.java
@@ -4,6 +4,7 @@ import lombok.*;
 import org.example.umcmission.domain.Mission;
 import org.example.umcmission.domain.Review;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -22,5 +23,29 @@ public class StoreResDTO {
         private List<Review> reviewList;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReviewPreViewListDTO {
+        List<ReviewPreViewDTO> reviewList;
+        Integer listSize;
+        Integer totalPage;
+        Long totalElements;
+        Boolean isFirst;
+        Boolean isLast;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReviewPreViewDTO {
+        String ownerNickname;
+        Float score;
+        String body;
+        LocalDate createdAt;
     }
 }

--- a/src/main/java/org/example/umcmission/repository/MemberMissionRespository.java
+++ b/src/main/java/org/example/umcmission/repository/MemberMissionRespository.java
@@ -2,8 +2,11 @@ package org.example.umcmission.repository;
 
 import org.example.umcmission.domain.enums.MissionStatus;
 import org.example.umcmission.domain.mapping.MemberMission;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberMissionRespository extends JpaRepository<MemberMission, Long> {
     boolean existsByMemberIdAndMissionIdAndStatus(Long memberId, Long missionId, MissionStatus status);
+    Page<MemberMission> findByMemberIdAndStatus(Long memberId, MissionStatus status, Pageable pageable);
 }

--- a/src/main/java/org/example/umcmission/repository/MissionRepository.java
+++ b/src/main/java/org/example/umcmission/repository/MissionRepository.java
@@ -2,7 +2,10 @@ package org.example.umcmission.repository;
 
 import org.example.umcmission.domain.Mission;
 import org.example.umcmission.domain.enums.MissionStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MissionRepository extends JpaRepository<Mission, Long> {
+    Page<Mission> findByStoreId(Long storeId, Pageable pageable);
 }

--- a/src/main/java/org/example/umcmission/repository/ReviewRepository.java
+++ b/src/main/java/org/example/umcmission/repository/ReviewRepository.java
@@ -1,7 +1,13 @@
 package org.example.umcmission.repository;
 
 import org.example.umcmission.domain.Review;
+import org.example.umcmission.domain.Store;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+    Page<Review> findAllByStore(Store store, PageRequest pageRequest);
+    Page<Review> findByMemberId(Long memberId, Pageable pageable);
 }

--- a/src/main/java/org/example/umcmission/service/MissionService/MemberMissionCommandService.java
+++ b/src/main/java/org/example/umcmission/service/MissionService/MemberMissionCommandService.java
@@ -1,0 +1,5 @@
+package org.example.umcmission.service.MissionService;
+
+public interface MemberMissionCommandService {
+    void completeMission(Long memberMissionId);
+}

--- a/src/main/java/org/example/umcmission/service/MissionService/MemberMissionCommandServiceImpl.java
+++ b/src/main/java/org/example/umcmission/service/MissionService/MemberMissionCommandServiceImpl.java
@@ -1,0 +1,29 @@
+package org.example.umcmission.service.MissionService;
+
+import lombok.RequiredArgsConstructor;
+import org.example.umcmission.domain.enums.MissionStatus;
+import org.example.umcmission.domain.mapping.MemberMission;
+import org.example.umcmission.repository.MemberMissionRespository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class MemberMissionCommandServiceImpl implements MemberMissionCommandService{
+    private final MemberMissionRespository memberMissionRespository;
+
+    @Override
+    public void completeMission(Long memberMissionId){
+        MemberMission memberMission = memberMissionRespository.findById(memberMissionId)
+                .orElseThrow(() -> new IllegalArgumentException("User mission not found"));
+
+        if (memberMission.getStatus() != MissionStatus.CHALLENGING) {
+            throw new IllegalStateException("Mission is not in progress");
+        }
+
+        memberMission.setStatus(MissionStatus.COMPLETE);
+        memberMission.setCompletedAt(LocalDateTime.now());
+        memberMissionRespository.save(memberMission);
+    }
+}

--- a/src/main/java/org/example/umcmission/service/MissionService/MemberMissionQueryService.java
+++ b/src/main/java/org/example/umcmission/service/MissionService/MemberMissionQueryService.java
@@ -1,0 +1,7 @@
+package org.example.umcmission.service.MissionService;
+
+import org.example.umcmission.dto.responseDTO.MemberMissionResDTO;
+
+public interface MemberMissionQueryService {
+    MemberMissionResDTO.MemberMissionListDTO getChallengingMissions(Long memberId, int page, int size);
+}

--- a/src/main/java/org/example/umcmission/service/MissionService/MemberMissionQueryServiceImpl.java
+++ b/src/main/java/org/example/umcmission/service/MissionService/MemberMissionQueryServiceImpl.java
@@ -1,0 +1,26 @@
+package org.example.umcmission.service.MissionService;
+
+import lombok.RequiredArgsConstructor;
+import org.example.umcmission.converter.MemberMissionConverter;
+import org.example.umcmission.domain.enums.MissionStatus;
+import org.example.umcmission.domain.mapping.MemberMission;
+import org.example.umcmission.dto.responseDTO.MemberMissionResDTO;
+import org.example.umcmission.repository.MemberMissionRespository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberMissionQueryServiceImpl implements  MemberMissionQueryService {
+    private final MemberMissionRespository memberMissionRespository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public MemberMissionResDTO.MemberMissionListDTO getChallengingMissions(Long memberId, int page, int size){
+        Page<MemberMission> memberMissions = memberMissionRespository.findByMemberIdAndStatus(memberId, MissionStatus.CHALLENGING, PageRequest.of(page, size));
+        return MemberMissionConverter.toUserMissionListDTO(memberMissions);
+    }
+
+}

--- a/src/main/java/org/example/umcmission/service/MissionService/MissionQueryService.java
+++ b/src/main/java/org/example/umcmission/service/MissionService/MissionQueryService.java
@@ -1,0 +1,7 @@
+package org.example.umcmission.service.MissionService;
+
+import org.example.umcmission.dto.responseDTO.MissionResDTO;
+
+public interface MissionQueryService {
+    MissionResDTO.MissionPreViewListDTO getMissions(Long storedId, int page, int size);
+}

--- a/src/main/java/org/example/umcmission/service/MissionService/MissionQueryServiceImpl.java
+++ b/src/main/java/org/example/umcmission/service/MissionService/MissionQueryServiceImpl.java
@@ -1,0 +1,25 @@
+package org.example.umcmission.service.MissionService;
+
+import lombok.RequiredArgsConstructor;
+import org.example.umcmission.converter.MissionConverter;
+import org.example.umcmission.domain.Mission;
+import org.example.umcmission.dto.responseDTO.MissionResDTO;
+import org.example.umcmission.repository.MissionRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MissionQueryServiceImpl implements MissionQueryService{
+    private final MissionRepository missionRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public MissionResDTO.MissionPreViewListDTO getMissions(Long storedId, int page, int size){
+        PageRequest pageRequest = PageRequest.of(page,size);
+        Page<Mission> missions = missionRepository.findByStoreId(storedId, pageRequest);
+        return MissionConverter.toMissionPreviewListDTO(missions);
+    }
+}

--- a/src/main/java/org/example/umcmission/service/ReviewService/ReviewQueryService.java
+++ b/src/main/java/org/example/umcmission/service/ReviewService/ReviewQueryService.java
@@ -1,0 +1,7 @@
+package org.example.umcmission.service.ReviewService;
+
+import org.example.umcmission.dto.responseDTO.ReviewResDTO;
+
+public interface ReviewQueryService {
+    ReviewResDTO.ReviewPreViewListDTO getReviews(Long memberId, int page, int size);
+}

--- a/src/main/java/org/example/umcmission/service/ReviewService/ReviewQueryServiceImpl.java
+++ b/src/main/java/org/example/umcmission/service/ReviewService/ReviewQueryServiceImpl.java
@@ -1,0 +1,26 @@
+package org.example.umcmission.service.ReviewService;
+
+import lombok.RequiredArgsConstructor;
+import org.example.umcmission.converter.ReviewConverter;
+import org.example.umcmission.domain.Review;
+import org.example.umcmission.dto.responseDTO.ReviewResDTO;
+import org.example.umcmission.repository.ReviewRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewQueryServiceImpl implements ReviewQueryService{
+    private final ReviewRepository reviewRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public ReviewResDTO.ReviewPreViewListDTO getReviews(Long memberId, int page, int size){
+        int validpage = Math.max(page - 1, 0);
+        Page<Review> reviews = reviewRepository.findByMemberId(memberId, PageRequest.of(validpage, size));
+        return ReviewConverter.toReviewPreviewListDTO(reviews);
+    }
+
+}

--- a/src/main/java/org/example/umcmission/service/StoreService/StoreQueryService.java
+++ b/src/main/java/org/example/umcmission/service/StoreService/StoreQueryService.java
@@ -1,6 +1,8 @@
 package org.example.umcmission.service.StoreService;
 
+import org.example.umcmission.domain.Review;
 import org.example.umcmission.domain.Store;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,4 +11,5 @@ public interface StoreQueryService {
 
     Optional<Store> findStore(Long id);
     List<Store> findStoresByNameAndScore(String name, Float score);
+    Page<Review> getReviewList(Long StoreId, Integer page);
 }

--- a/src/main/java/org/example/umcmission/service/StoreService/StoreQueryServiceImpl.java
+++ b/src/main/java/org/example/umcmission/service/StoreService/StoreQueryServiceImpl.java
@@ -1,8 +1,12 @@
 package org.example.umcmission.service.StoreService;
 
 import lombok.RequiredArgsConstructor;
+import org.example.umcmission.domain.Review;
 import org.example.umcmission.domain.Store;
+import org.example.umcmission.repository.ReviewRepository;
 import org.example.umcmission.repository.StoreRepository.StoreRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +19,7 @@ import java.util.Optional;
 public class StoreQueryServiceImpl implements StoreQueryService{
 
     private final StoreRepository storeRepository;
+    private final ReviewRepository reviewRepository;
 
     @Override
     public Optional<Store> findStore(Long id) {
@@ -28,5 +33,13 @@ public class StoreQueryServiceImpl implements StoreQueryService{
         filteredStores.forEach(store -> System.out.println("Store: " + store));
 
         return filteredStores;
+    }
+
+    @Override
+    public Page<Review> getReviewList(Long StoreId, Integer page) {
+        Store store = storeRepository.findById(StoreId).get();
+
+        Page<Review> StorePage = reviewRepository.findAllByStore(store, PageRequest.of(page, 10));
+        return StorePage;
     }
 }

--- a/src/main/java/org/example/umcmission/validation/annotaion/CheckPage.java
+++ b/src/main/java/org/example/umcmission/validation/annotaion/CheckPage.java
@@ -1,0 +1,17 @@
+package org.example.umcmission.validation.annotaion;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import org.example.umcmission.validation.validator.PageValidator;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = PageValidator.class)
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckPage {
+    String message() default "page는 1보다 크거나 같아야합니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/org/example/umcmission/validation/validator/PageValidator.java
+++ b/src/main/java/org/example/umcmission/validation/validator/PageValidator.java
@@ -1,0 +1,18 @@
+package org.example.umcmission.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.example.umcmission.validation.annotaion.CheckPage;
+
+public class PageValidator implements ConstraintValidator<CheckPage, Integer> {
+    @Override
+    public boolean isValid(Integer value, ConstraintValidatorContext context) {
+        if (value == null || value < 1) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate("Page는 1보다 크거나 같아야합니다.")
+                    .addConstraintViolation();
+            return false;
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
**구현이 필요한 API 목록**

1. 내가 작성한 리뷰 목록        
2. 특정 가게의 미션 목록
3. 내가 진행중인 미션 목록
4. 진행중인 미션 진행 완료로 바꾸기

**API 구현 조건**

1. 반드시 Paging처리를 할 것, 한 페이지에 10개씩 조회 **프론트엔드는 1 이상의 page 번호를 전달**
2. 필요한 데이터는 데이터베이스에서 직접 삽입을 해서 진행 (미션 외 API는 구현해도 됨) 
    1. 다만 미션 외 API는 작성을 해도 구현한 API 갯수로 카운트가 되지 않음
3. 프론트엔드가 주는 page는 쿼리 스트링으로 받아오며 이에 대한 처리를 하는 커스텀 어노테이션 구현을 반드시 할 것 
    1. 1번의 page 범위에 따라 커스텀 어노테이션은 page 1을 0으로 만들어 return 해야 한다.
    2. 그와 동시에 page의 범위가 너무 작은지 (0 이하) 판단을 하여 작은 경우 에러를 발생
    3. 에러 발생 시 반드시 RestControllerAdvice와 연계를 해야 함
    4. 커스텀 어노테이션은 아래처럼 사용을 하도록 구현
4. 반드시 모든 API에 대해 Swagger 명세를 해야 한다. 
5. Converter에서 절대로 for문을 사용해서는 안되며, 무조건 Java의 Stream을 사용해야 한다.
6. 무조건 빌더 패턴을 사용해야 한다.
7. API 구현